### PR TITLE
PR For Issue #10 - Collects spent reminders and deletes them at end of day

### DIFF
--- a/CustomReminders/src/CustomReminders.cs
+++ b/CustomReminders/src/CustomReminders.cs
@@ -87,6 +87,12 @@ namespace Dem1se.CustomReminders
                 Directory.CreateDirectory(Path.Combine(Helper.DirectoryPath, "data", Utilities.Globals.SaveFolderName));
                 Monitor.Log("Reminders directory created successfully.", LogLevel.Info);
             }
+            
+            //Json-x-ly Notes: Wipes the Queue for the new save context
+            DeleteQueue.Clear();
+
+            //Json-x-ly Notes: Checks to see if there are any mature reminders at start of day on load
+            ReminderNotifierLoop(Game1.timeOfDay);
         }
 
         /// <summary> Defines what happens when user press the config button </summary>
@@ -156,13 +162,19 @@ namespace Dem1se.CustomReminders
         }
 
         /// <summary> Loop that checks if any reminders are mature.</summary>
-        private void ReminderNotifier(object sender, TimeChangedEventArgs ev)
+        private void ReminderNotifier(object sender, TimeChangedEventArgs ev) {
+            ReminderNotifierLoop(ev.NewTime);
+        }
+
+        // Json-x-ly Notes: Separated for OnSaveLoaded check since loading a new game does not send a TimeChanged event for the 600 hour 
+        private void ReminderNotifierLoop(int newTime) 
         {
             // returns function if game time isn't multiple of 30 in-game minutes.
-            string timeString = Convert.ToString(ev.NewTime);
+            string timeString = Convert.ToString(newTime);
             if (!(timeString.EndsWith("30") || timeString.EndsWith("00"))) return;
 
             // Loops through all the reminder files and evaluates if they are current.
+            
             #region ReminderNotifierloop
             SDate currentDate = SDate.Now();
             foreach (string filePathAbsolute in Directory.EnumerateFiles(Path.Combine(Helper.DirectoryPath, "data", Utilities.Globals.SaveFolderName)))
@@ -173,16 +185,16 @@ namespace Dem1se.CustomReminders
                     string filePathRelative = Utilities.Extras.MakeRelativePath(filePathAbsolute);
 
                     // Read the reminder and notify if mature
-                    Monitor.Log($"Processing {ev.NewTime}");
+                    Monitor.Log($"Processing {newTime}");
                     ReminderModel Reminder = Helper.Data.ReadJsonFile<ReminderModel>(filePathRelative);
                     if (Reminder.DaysSinceStart == currentDate.DaysSinceStart)
                     {
-                        if (Reminder.Time == ev.NewTime)
+                        if (Reminder.Time == newTime)
                         {
                             Game1.addHUDMessage(new HUDMessage(Reminder.ReminderMessage, 2));
                             Game1.playSound(NotificationSound);
                             Monitor.Log($"Reminder notified for {Reminder.DaysSinceStart}: {Reminder.ReminderMessage}", LogLevel.Info);
-                            File.Delete(filePathAbsolute);
+                            // Store the path for deletion later.
                             DeleteQueue.Enqueue(filePathAbsolute);
                         }
                         /* this is a very rare case (should be impossible) and won't happen normally, but I've still included it just in case,

--- a/CustomReminders/src/UI/DisplayReminders.cs
+++ b/CustomReminders/src/UI/DisplayReminders.cs
@@ -7,6 +7,7 @@ using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using StardewModdingAPI.Utilities;
 
 namespace Dem1se.CustomReminders.UI
 {
@@ -122,12 +123,19 @@ namespace Dem1se.CustomReminders.UI
         }
 
         /// <summary>This fills the Reminders list by reading all the reminder files</summary>
-        private void PopulateRemindersList()
+        private void PopulateRemindersList() 
         {
+            SDate now = SDate.Now();
             foreach (string AbsoulutePath in Directory.GetFiles(Path.Combine(Utilities.Globals.Helper.DirectoryPath, "data", Utilities.Globals.SaveFolderName)))
             {
                 string RelativePath = Utilities.Extras.MakeRelativePath(AbsoulutePath);
-                Reminders.Add(Utilities.Globals.Helper.Data.ReadJsonFile<ReminderModel>(RelativePath));
+                ReminderModel Reminder = Utilities.Globals.Helper.Data.ReadJsonFile<ReminderModel>(RelativePath);
+                //Json-x-ly Notes: Threw this check in since now there are entries that are spent, but still awaiting cleanup. Implies to the user that the Reminder is gone.
+                // -- Changing the "Reminder.Time < Game1.timeOfDay" to "Reminder.Time <= Game1.timeOfDay" determines if the entry is left in the list for the actual moment in time it's triggered.
+                // If Reminder is today or earlier and Reminders Time is earlier then now, omit the entry.
+                if (Reminder.DaysSinceStart <= now.DaysSinceStart && Reminder.Time < Game1.timeOfDay) continue;
+                
+                Reminders.Add(Reminder);
             }
         }
 


### PR DESCRIPTION
Addresses Issue #10 

Here's the fixes I made for my own use. I tried to document them as best as I could, probably went overboard honestly. 

Beyond the delayed deletions, I also threw in a fix for a different issue I noticed while testing this. The GameLoop.SaveLoaded event doesn't appear to trigger a GameLoop.TimeChanged event for the initial 600 wakeup time, so I threw the ReminderNotificationLoop region into a separate method from the event delegate and called it at the end of the OnSaveLoaded method to catch any early morning Reminders ( I use 600 reminders a lot for the cooking channel : D )

I also added a little check into the PopulateReminderList that omits any reminders that are older then the current time. Might be a better way to address this, but that was the cleanest point I could find without doing something drastic like changing the data model or something.